### PR TITLE
allow end time to be a string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -199,7 +199,7 @@
 		url = url.replace( /\{\{start\}\}/, start );
 
 		// Set the end time:
-		if ( typeof end === 'number' && end === end ) {
+		if ( (typeof end === 'number' || typeof end === 'string') && end === end ) {
 			url = url.replace( /\{\{end\}\}/, end );
 		} else {
 			url = url.replace( /end=\{\{end\}\}&/, '' );

--- a/test/test.js
+++ b/test/test.js
@@ -312,6 +312,24 @@ describe( 'opentsdb-url', function tests() {
 
 			assert.notOk( new RegExp( '&end=' ).test( url ), 'Incorrectly contains an end time parameter.' );
 		});
+		
+		it( 'should include an end time if end is a string', function test() {
+			var client = createClient(),
+				query = mQuery(),
+				url = createFactory( client ),
+				end = '2010/12/23-07:54:25';
+
+			setMetricQuery( query );
+			setClient( client, query );
+
+			// Absolute end time:
+			client.end( end );
+			
+			url = url.template()
+				.create();
+				
+			assert.ok( new RegExp( 'end='+end ).test( url ), 'Does not contain end time.' );
+		});
 
 		it( 'should properly encode annotations preferences', function test() {
 			var client = createClient(),


### PR DESCRIPTION
Accept absolute date-time format as an end time.

Rather than working with unix time I'd like to switch to working with absolute times. The only thing preventing this for me is this number restriction on end time when creating the url.
